### PR TITLE
ARM compatible docker image

### DIFF
--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-FROM resin/raspberry-pi-alpine
+FROM arm32v6/alpine
 
 LABEL maintainer="David Coppit<david@coppit.org>"
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -38,6 +38,9 @@ RUN set -x \
   && mv /files/noip-2.1.9-1/noip2 /files \
   && rm -rf /files/noip-2.1.9-1 /files/noip-duc-linux.tar.gz
 
+#Compatibilty with x86_64 based scripts
+RUN ln -s /files/noip2 /files/noip2-x86_64
+
 COPY ["noip.conf", "create_config.exp", "/files/"]
 
 # run-parts ignores files with "." in them

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,0 +1,47 @@
+FROM arm32v6/alpine
+
+MAINTAINER David Coppit <david@coppit.org>
+
+ENV TERM=xterm-256color
+
+RUN true && \
+\
+echo "http://dl-cdn.alpinelinux.org/alpine/v3.7/community" >> /etc/apk/repositories && \
+apk --update upgrade && \
+\
+# Basics, including runit
+apk add bash curl htop runit && \
+\
+# Needed by our code
+apk add expect libc6-compat && \
+\
+rm -rf /var/cache/apk/* && \
+\
+# RunIt stuff
+adduser -h /home/user-service -s /bin/sh -D user-service -u 2000 && \
+chown user-service:user-service /home/user-service && \
+mkdir -p /etc/run_once /etc/service
+
+# Boilerplate startup code
+COPY ./boot.sh /sbin/boot.sh
+RUN chmod +x /sbin/boot.sh
+CMD [ "/sbin/boot.sh" ]
+
+VOLUME ["/config"]
+
+ADD https://www.noip.com/client/linux/noip-duc-linux.tar.gz /files/
+
+RUN set -x \
+  && chmod a+rwX /files \
+  && tar -C /files -x -f /files/noip-duc-linux.tar.gz noip-2.1.9-1/binaries/noip2-x86_64 \
+  && mv /files/noip-2.1.9-1/binaries/noip2-x86_64 /files \
+  && rm -rf /files/noip-2.1.9-1 /files/noip-duc-linux.tar.gz
+
+COPY ["noip.conf", "create_config.exp", "/files/"]
+
+# run-parts ignores files with "." in them
+COPY parse_config_file.sh /etc/run_once/parse_config_file
+RUN chmod +x /etc/run_once/parse_config_file
+
+COPY noip.sh /etc/service/noip/run
+RUN chmod +x /etc/service/noip/run

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,6 +1,6 @@
-FROM arm32v6/alpine
+FROM resin/raspberry-pi-alpine
 
-MAINTAINER David Coppit <david@coppit.org>
+LABEL maintainer="David Coppit<david@coppit.org>"
 
 ENV TERM=xterm-256color
 
@@ -13,7 +13,7 @@ apk --update upgrade && \
 apk add bash curl htop runit && \
 \
 # Needed by our code
-apk add expect libc6-compat && \
+apk add expect libc6-compat make gcc libc-dev && \
 \
 rm -rf /var/cache/apk/* && \
 \
@@ -33,8 +33,9 @@ ADD https://www.noip.com/client/linux/noip-duc-linux.tar.gz /files/
 
 RUN set -x \
   && chmod a+rwX /files \
-  && tar -C /files -x -f /files/noip-duc-linux.tar.gz noip-2.1.9-1/binaries/noip2-x86_64 \
-  && mv /files/noip-2.1.9-1/binaries/noip2-x86_64 /files \
+  && tar -C /files -x -f /files/noip-duc-linux.tar.gz  \
+  && cd /files/noip-2.1.9-1 && make \ 
+  && mv /files/noip-2.1.9-1/noip2 /files \
   && rm -rf /files/noip-2.1.9-1 /files/noip-duc-linux.tar.gz
 
 COPY ["noip.conf", "create_config.exp", "/files/"]
@@ -44,4 +45,6 @@ COPY parse_config_file.sh /etc/run_once/parse_config_file
 RUN chmod +x /etc/run_once/parse_config_file
 
 COPY noip.sh /etc/service/noip/run
+#Look into using intermediate builder image instead
+RUN apk del gcc make libc-dev
 RUN chmod +x /etc/service/noip/run


### PR DESCRIPTION
Based on `arm32v6/alpine` and x86_64 Dockerfile, with some minor tweaks.

Built image available at https://hub.docker.com/r/demaniak/armhf-noip/

